### PR TITLE
Add cloudfront.net in include-hosts-dist.txt

### DIFF
--- a/rootfs/root/antizapret/config/include-hosts-dist.txt
+++ b/rootfs/root/antizapret/config/include-hosts-dist.txt
@@ -11,6 +11,7 @@ bbci.co.uk
 buymeacoffee.com
 cdninstagram.com
 cloudflare.com
+cloudfront.net
 deezer.com
 fanatical.com
 game-debate.com


### PR DESCRIPTION
Не загружается hub.docker.com без cloudfront.net.