### PR TITLE
Add mongodb-cdn.com in include-hosts-dist.txt

### DIFF
--- a/rootfs/root/antizapret/config/include-hosts-dist.txt
+++ b/rootfs/root/antizapret/config/include-hosts-dist.txt
@@ -110,6 +110,7 @@ nnmclub.ch
 docker.com
 mongodb.com
 mongodb.net
+mongodb-cdn.com
 jetbrains.com
 code.org
 veeam.com


### PR DESCRIPTION
Не загружается сайт mongodb.com без туннелирования mongodb-cdn.com