### PR TITLE
feat(wireguard): add the ability to specify a password as a hash

### DIFF
--- a/wireguard/entrypoint.sh
+++ b/wireguard/entrypoint.sh
@@ -60,7 +60,11 @@ if [[ ${FORCE_FORWARD_DNS:-true} == true ]]; then
     done
 fi
 
-PASSWORD_HASH="$(wgpw "$WIREGUARD_PASSWORD" | sed "s/'//g" | sed 's/PASSWORD_HASH=//g')"
+if [ -n "$WIREGUARD_PASSWORD_HASH" ]; then
+    PASSWORD_HASH="$WIREGUARD_PASSWORD_HASH"
+else
+    PASSWORD_HASH="$(wgpw "$WIREGUARD_PASSWORD" | sed "s/'//g" | sed 's/PASSWORD_HASH=//g')"
+fi
 export PASSWORD_HASH
 
 exec /usr/bin/dumb-init node server.js


### PR DESCRIPTION
Added the ability to specify a password as a hash using the WIREGUARD_PASSWORD_HASH environment variable.