### PR TITLE
feat: add the ability to specify a password as a hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Antizapret:
 - `ADGUARDHOME_PORT=3000`
 - `ADGUARDHOME_USERNAME=admin`
 - `ADGUARDHOME_PASSWORD=`
+- `ADGUARDHOME_PASSWORD_HASH=` - hashed password, taken from the AdGuardHome.yaml file after the first run using `ADGUARDHOME_PASSWORD`
 - `DNS=1.1.1.1` - Upstream DNS for resolving blocked sites
 - `ROUTES` - list of VPN containers and their virtual addresses. Needed for uniq client addresses in adguard logs 
 
@@ -159,6 +160,7 @@ Openvpn-ui
 
 Wireguard/Wireguard Amnezia
 - `WIREGUARD_PASSWORD=` - password for admin panel
+- `WIREGUARD_PASSWORD_HASH=` - [hashed password](https://github.com/wg-easy/wg-easy/blob/master/How_to_generate_an_bcrypt_hash.md) for admin panel
 - `ANTIZAPRET_SUBNET=10.224.0.0/15` - subnet for virtual blocked ips
 - `WG_DEFAULT_DNS=10.224.0.1` - DNS address for clients. Must be in `ANTIZAPRET_SUBNET`
 - `WG_PERSISTENT_KEEPALIVE=25`

--- a/wireguard/entrypoint.sh
+++ b/wireguard/entrypoint.sh
@@ -60,7 +60,11 @@ if [[ ${FORCE_FORWARD_DNS:-true} == true ]]; then
     done
 fi
 
-PASSWORD_HASH="$(wgpw "$WIREGUARD_PASSWORD" | sed "s/'//g" | sed 's/PASSWORD_HASH=//g')"
+if [ -n "$WIREGUARD_PASSWORD_HASH" ]; then
+    PASSWORD_HASH="$WIREGUARD_PASSWORD_HASH"
+else
+    PASSWORD_HASH="$(wgpw "$WIREGUARD_PASSWORD" | sed "s/'//g" | sed 's/PASSWORD_HASH=//g')"
+fi
 export PASSWORD_HASH
 
 exec /usr/bin/dumb-init node server.js


### PR DESCRIPTION
### 📝 Changes  

✅ Added support for specifying a password as a hash via the `WIREGUARD_PASSWORD_HASH` environment variable.  
✅ Documented `ADGUARDHOME_PASSWORD_HASH` usage.  

### 🔍 Why?  

🔹 Improves security by avoiding plain text passwords.
