### PR TITLE
fix: filebrowser. 500 internal error. Permission denied

### DIFF
--- a/services/filebrowser/hooks/doall.sh
+++ b/services/filebrowser/hooks/doall.sh
@@ -4,6 +4,6 @@ STAGE_1=false
 STAGE_2=true
 STAGE_3=true
 
-curl -X POST http://antizapret:8080/doall \
+curl -X POST http://az-local.antizapret:80/doall \
      -H "Content-Type: application/json" \
      -d '{ "stage_1": '"$STAGE_1"', "stage_2": '"$STAGE_2"', "stage_3": '"$STAGE_3"' }'


### PR DESCRIPTION
## Description:
This PR updates the filebrowser service configuration to reflect the new host naming scheme and port changes.

### Changes:

   * Changed the host reference from the old inaccessible host to az-local.antizapret
   * Updated the port from 8080 to 80
   * Fixed permissions for the service configuration files (chmod +x doall.sh)
