### PR TITLE
improve update-crl script for openvpn-ui

### DIFF
--- a/services/openvpn/files-ui/ui-start.sh
+++ b/services/openvpn/files-ui/ui-start.sh
@@ -59,6 +59,7 @@ EOS
 
 fi
 
+./update-crl.sh;
 while true; do
     sleep 86400;
     echo "Update crl";

--- a/services/openvpn/files-ui/update-crl.sh
+++ b/services/openvpn/files-ui/update-crl.sh
@@ -1,12 +1,70 @@
 #!/usr/bin/env bash
 
-set -ex
+set -euo pipefail
 
+# Configuration
 EASY_RSA="/usr/share/easy-rsa"
-TEMP_PKI_DIR=/tmp/pki
-mkdir -p $TEMP_PKI_DIR
+CRL_PATH="/etc/openvpn/pki/crl.pem"       # Where OpenVPN looks for the CRL
+THRESHOLD=86400                           # Update if less than 24 hours (86400 sec) remain
 
-cd "$EASY_RSA"
-$EASY_RSA/easyrsa gen-crl
-chmod +r $EASY_RSA/pki/crl.pem
-openssl crl -in /etc/openvpn/pki/crl.pem -text | grep -E "Last|Next"
+# Function to parse OpenSSL date string (e.g. "Jul 16 10:58:42 2026 GMT") to epoch seconds (UTC)
+parse_date_to_epoch() {
+    local datestr="$1"
+    # Remove trailing " GMT" or " UTC" and normalize spaces
+    datestr=$(echo "$datestr" | sed 's/ \(GMT\|UTC\)$//; s/^ *//; s/  */ /g')
+    
+    # Expected format: "Jul 16 10:58:42 2026"
+    local month_str=$(echo "$datestr" | awk '{print $1}')
+    local day=$(echo "$datestr" | awk '{print $2}')
+    local time=$(echo "$datestr" | awk '{print $3}')
+    local year=$(echo "$datestr" | awk '{print $4}')
+    
+    case "$month_str" in
+        Jan) month=01 ;; Feb) month=02 ;; Mar) month=03 ;; Apr) month=04 ;;
+        May) month=05 ;; Jun) month=06 ;; Jul) month=07 ;; Aug) month=08 ;;
+        Sep) month=09 ;; Oct) month=10 ;; Nov) month=11 ;; Dec) month=12 ;;
+        *) echo "ERROR: Unknown month $month_str" >&2; exit 1 ;;
+    esac
+    
+    local formatted="${year}-${month}-${day} ${time}"
+    date -u -d "$formatted" +%s
+}
+
+# Function to actually update CRL
+update_crl() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') Updating CRL..."
+
+    cd "$EASY_RSA"
+    "$EASY_RSA/easyrsa" gen-crl
+    chmod +r $EASY_RSA/pki/crl.pem
+    echo "$(date '+%Y-%m-%d %H:%M:%S') CRL updated successfully"
+}
+
+need_update=false
+
+if [[ ! -f "$CRL_PATH" ]]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') CRL file missing → updating"
+    need_update=true
+else
+    nextupdate_str=$(openssl crl -in "$CRL_PATH" -noout -nextupdate 2>/dev/null | cut -d= -f2-)
+    if [[ -z "$nextupdate_str" ]]; then
+        echo "$(date '+%Y-%m-%d %H:%M:%S') Cannot read nextupdate → updating"
+        need_update=true
+    else
+        nextupdate_epoch=$(parse_date_to_epoch "$nextupdate_str")
+        current_epoch=$(date -u +%s)
+        remaining=$((nextupdate_epoch - current_epoch))
+
+        if [[ $remaining -le 0 ]]; then
+            echo "$(date '+%Y-%m-%d %H:%M:%S') CRL expired (remaining: $remaining sec) → updating"
+            need_update=true
+        elif [[ $remaining -le $THRESHOLD ]]; then
+            echo "$(date '+%Y-%m-%d %H:%M:%S') Less than $THRESHOLD sec remaining ($remaining sec) → updating"
+            need_update=true
+        fi
+    fi
+fi
+
+if [[ $need_update == true ]]; then
+    update_crl
+fi


### PR DESCRIPTION
**Description:**  
This PR changes the CRL (Certificate Revocation List) update mechanism from a fixed time-based schedule to an **on-demand approach**.  

Key improvements:
- CRL is now refreshed **only when necessary** (e.g., when validation requires it), rather than at fixed intervals.
- If the current CRL is **already expired**, the update happens **immediately**—instead of waiting up to 24 hours as before.