### PR TITLE
Add world-specific custom hosts files for separate world/local management via filebrowser

### DIFF
--- a/services/adguard/AdGuardHome.yaml
+++ b/services/adguard/AdGuardHome.yaml
@@ -112,7 +112,7 @@ filters:
     name: Custom Local Rules
     id: 4
   - enabled: true
-    url: http://az-world.antizapret/list/?file=/root/antizapret/config/custom/include-hosts-custom.txt
+    url: http://az-world.antizapret/list/?file=/root/antizapret/config/custom/include-hosts-world-custom.txt
     name: Custom World Rules
     id: 5
   - enabled: true

--- a/services/antizapret/api/main.go
+++ b/services/antizapret/api/main.go
@@ -271,6 +271,9 @@ func adaptList(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			filtered, _ = excludeMatcherCustom.Filter(filtered)
+			if excludeMatcherCustomWorld != nil {
+				filtered, _ = excludeMatcherCustomWorld.Filter(filtered)
+			}
 		}
 
 		for _, line := range filtered {
@@ -377,6 +380,21 @@ func updateRegexFilter() error {
 	excludeMatcherCustom, error = NewRegexFilter(
 		"/root/antizapret/config/custom/exclude-hosts-custom.txt",
 	)
+	if error != nil {
+		return error
+	}
+
+	if DefaultClient == "az-world" {
+		if excludeMatcherCustomWorld != nil {
+			if err := excludeMatcherCustomWorld.Close(); err != nil {
+				return err
+			}
+		}
+
+		excludeMatcherCustomWorld, error = NewRegexFilter(
+			"/root/antizapret/config/custom/exclude-hosts-world-custom.txt",
+		)
+	}
 	return error
 }
 
@@ -460,6 +478,9 @@ func main() {
 		}
 		if excludeMatcherCustom != nil {
 			excludeMatcherCustom.Close()
+		}
+		if excludeMatcherCustomWorld != nil {
+			excludeMatcherCustomWorld.Close()
 		}
 	}()
 	// Create a mux so we can wrap all handlers with logging

--- a/services/antizapret/api/main.go
+++ b/services/antizapret/api/main.go
@@ -73,6 +73,7 @@ type RegexFilter struct {
 
 var excludeMatcherDist *RegexFilter
 var excludeMatcherCustom *RegexFilter
+var excludeMatcherCustomWorld *RegexFilter
 
 const delim = "__DELIM__"
 

--- a/services/antizapret/init.sh
+++ b/services/antizapret/init.sh
@@ -27,7 +27,7 @@ ln -sf /etc/default/antizapret /etc/profile.d/antizapret.sh
 
 
 # creating custom hosts files if they have not yet been initialized
-for file in $(echo {exclude,include}-{hosts,ips,ips-world}-custom.txt); do
+for file in $(echo {exclude,include}-{hosts,hosts-world,ips,ips-world}-custom.txt); do
     path=/root/antizapret/config/custom/$file
     [ ! -f $path ] && touch $path
 done

--- a/services/filebrowser/hooks/doall.sh
+++ b/services/filebrowser/hooks/doall.sh
@@ -7,3 +7,7 @@ STAGE_3=true
 curl -X POST http://az-local.antizapret:80/doall \
      -H "Content-Type: application/json" \
      -d '{ "stage_1": '"$STAGE_1"', "stage_2": '"$STAGE_2"', "stage_3": '"$STAGE_3"' }'
+
+curl -X POST http://az-world.antizapret:80/doall \
+     -H "Content-Type: application/json" \
+     -d '{ "stage_1": '"$STAGE_1"', "stage_2": '"$STAGE_2"', "stage_3": '"$STAGE_3"' }'


### PR DESCRIPTION
Both az-local and az-world shared a single include-hosts-custom.txt and exclude-hosts-custom.txt, making it impossible to manage domain lists on file manager independently per exit node. The -world- naming convention already existed for IP custom files but was missing for hosts.

### Changes

- **`services/antizapret/init.sh`** — Expand file creation brace to `{hosts,hosts-world,ips,ips-world}`, adding `include-hosts-world-custom.txt` and `exclude-hosts-world-custom.txt`
- **`services/adguard/AdGuardHome.yaml`** — Point "Custom World Rules" filter at `include-hosts-world-custom.txt` instead of sharing `include-hosts-custom.txt`
- **`services/antizapret/api/main.go`** — Load `exclude-hosts-world-custom.txt` as an additional `RegexFilter` when `CLIENT == "az-world"`, applied alongside the base custom exclude filter
- **`services/filebrowser/hooks/doall.sh`** — Trigger doall on `az-world` in addition to `az-local` so filebrowser saves propagate to both nodes

### Result in filebrowser

Files are distinguished by the `-world-` infix, consistent with existing IP files:

```
include-hosts-custom.txt          # local
include-hosts-world-custom.txt    # world
exclude-hosts-custom.txt          # local
exclude-hosts-world-custom.txt    # world
```