### PR TITLE
Fix Docker image reference

### DIFF
--- a/services/antizapret/docker-compose.yml
+++ b/services/antizapret/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   antizapret:
-    image: xtrime/antizapret-vpn:6.1.0@sha256:aa326a5f38a634d8de15776c74ed484905dd80946d416c16790a034d8b1feb72
+    image: xtrime/antizapret-vpn:6.1.0
     restart: unless-stopped
     stop_signal: SIGRTMIN+4
     init: true


### PR DESCRIPTION
## Fix Docker image reference in docker-compose

### Description
Removed the digest suffix from the Docker image name in docker-compose.yml, as using a digest as part of the tag causes a build error:

```
 docker compose build
 ....
  => ERROR [az-local] exporting to image                                                                                                      0.0s
 => => exporting layers                                                                                                                      0.0s
 => => writing image sha256:71221ad6b61bad13a9479d9f5e0720dff2ad6af9c005cbd7e52ada71e552b4ad                                                 0.0s
 => => naming to docker.io/xtrime/antizapret-vpn:6.1.0@sha256:aa326a5f38a634d8de15776c74ed484905dd80946d416c16790a034d8b1feb72               0.0s
 => [firewall] exporting to image                                                                                                            0.0s
 => => exporting layers                                                                                                                      0.0s
 => => writing image sha256:f640aaded51edf48ec66b3d4917b94c13e254b44863bbfd43b17156a8bff2c85                                                 0.0s
 => => naming to docker.io/xtrime/antizapret-vpn-firewall:5.3.4                                                                              0.0s
 => ERROR [az-world] exporting to image                                                                                                      0.0s
 => => exporting layers                                                                                                                      0.0s
 => => writing image sha256:71221ad6b61bad13a9479d9f5e0720dff2ad6af9c005cbd7e52ada71e552b4ad                                                 0.0s
 => => naming to docker.io/xtrime/antizapret-vpn:6.1.0@sha256:aa326a5f38a634d8de15776c74ed484905dd80946d416c16790a034d8b1feb72               0.0s
------
 > [az-local] exporting to image:
------
------
 > [az-world] exporting to image:
------
target az-local: failed to solve: refusing to create a tag with a digest reference
```


Docker does not allow specifying a digest in the image field when building or tagging images. The digest should only be used for pulling or referencing existing images, not for defining the target image name in a build context.