### PR TITLE
Fix timezone bind mounts

### DIFF
--- a/services/adguard/docker-compose.yml
+++ b/services/adguard/docker-compose.yml
@@ -26,6 +26,7 @@ services:
         max-size: 100k
         max-file: 2
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - $PWD/config/adguard/conf:/opt/adguardhome/conf
       - $PWD/config/adguard/work:/opt/adguardhome/work
     deploy:

--- a/services/antizapret/docker-compose.yml
+++ b/services/antizapret/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       start_period: 5s
       start_interval: 1s
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - $PWD/config/antizapret/custom:/root/antizapret/config/custom
       - $PWD/config/antizapret/result:/root/antizapret/result
       - $PWD/config/antizapret/iptables:/root/antizapret/iptables

--- a/services/cloak/docker-compose.yml
+++ b/services/cloak/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - 443:443
     volumes:
-      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
       - $PWD/config/cloak:/opt/cloak
     deploy:
       mode: replicated

--- a/services/coredns/docker-compose.yml
+++ b/services/coredns/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       options:
         max-size: 100k
         max-file: 2
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
     healthcheck:
       test: (/root/healthcheck.sh || kill -TERM 1) 2>&1 | tee /proc/1/fd/1
       interval: 10s

--- a/services/dashboard/docker-compose.yml
+++ b/services/dashboard/docker-compose.yml
@@ -10,7 +10,7 @@ services:
           - linux/amd64
           - linux/arm64
     volumes:
-      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
     environment:
       - DASHBOARD_USERNAME=admin
       - DASHBOARD_PASSWORD=password

--- a/services/filebrowser/docker-compose.yml
+++ b/services/filebrowser/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         max-size: 100k
         max-file: 2
     volumes:
-      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
       - $PWD/config/antizapret/custom:/srv
     depends_on:
       - az-local

--- a/services/firewall/docker-compose.yml
+++ b/services/firewall/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - SYS_MODULE
     working_dir: /root
     entrypoint: /root/entrypoint.sh
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
     environment:
       - INTERVAL=3h
       - V4_URL=https://raw.githubusercontent.com/C24Be/AS_Network_List/refs/heads/main/blacklists/blacklist-v4.txt

--- a/services/https/docker-compose.yml
+++ b/services/https/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - PROXY_SERVICE_7=HTTP PROXY LOCAL:8143:proxy-local.antizapret:8180
       - PROXY_SERVICE_8=HTTP PROXY WORLD:8243:proxy-world.antizapret:8180
     volumes:
-      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
       - $PWD/config/https/data:/data
       - $PWD/config/https/config:/config
     depends_on:

--- a/services/ocserv/compose.yml
+++ b/services/ocserv/compose.yml
@@ -57,6 +57,7 @@ services:
         az-local:14.16.0.0/15;
         az-world:14.18.0.0/15;
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - $PWD/config/ocserv:/etc/ocserv
       - $PWD/config/antizapret/result:/opt/antizapret/result
     ports:

--- a/services/openvpn/docker-compose.yml
+++ b/services/openvpn/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       start_period: 5s
       start_interval: 1s
     volumes:
-      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
       - $PWD/config/openvpn:/etc/openvpn
       - $PWD/config/antizapret/result:/opt/antizapret/result
     ports:
@@ -66,7 +66,7 @@ services:
           - linux/amd64
           - linux/arm64
     volumes:
-      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - $PWD/config/openvpn/db:/opt/openvpn-ui/db
       - $PWD/config/openvpn/pki:/usr/share/easy-rsa/pki

--- a/services/proxy/compose.yml
+++ b/services/proxy/compose.yml
@@ -21,6 +21,8 @@ services:
     sysctls:
       - net.ipv4.ip_forward=1
       - net.ipv4.conf.all.src_valid_mark=1
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
     environment:
       - PRIMARY_RESOLVER=14.16.0.1
       - PROXY_LOGIN=

--- a/services/wireguard/docker-compose.base.yml
+++ b/services/wireguard/docker-compose.base.yml
@@ -33,6 +33,7 @@ services:
     depends_on:
       - az-local
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - $PWD/config/antizapret/result:/opt/antizapret/result
     deploy:
       mode: replicated


### PR DESCRIPTION
## Summary

Replace `/etc/timezone` bind mounts with `/etc/localtime` across service compose files.

`/etc/timezone` is not present on newer mainstream distributions such as Debian 13 and Ubuntu 26.04 with current `tzdata`, while `/etc/localtime` is the system timezone source used by libc, Go, and standard Linux tooling.

> [!IMPORTANT]
> Mounting only `/etc/timezone` did not set the runtime timezone inside containers before either. It only copied a textual timezone name, while common runtimes and tools use `/etc/localtime` unless `TZ` is explicitly set.

## Changes

- Remove all `/etc/timezone:/etc/timezone:ro` mounts.
- Add `/etc/localtime:/etc/localtime:ro` to runtime service definitions that need host-local time.
- Keep inherited services such as `socks` covered through their base service configuration.

## Verification

- Confirmed no `/etc/timezone` references remain in compose files.
- Confirmed `/etc/localtime` is rendered in `docker compose -f docker-compose.yml config`.
- Verified optional compose renders do not reintroduce `/etc/timezone`.